### PR TITLE
Changes to allow custom MySQL server to be used

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8
+FROM openjdk:8-stretch
 
 ENV KNOWAGE_VERSION 6_3_3
 ENV KNOWAGE_EDITION CE

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Knowage is the professional open source suite for modern business analytics over
  
 ## Supported tags and respective Dockerfile links
 
-* ```latest``` : [Dockerfile](https://raw.githubusercontent.com/KnowageLabs/Knowage-Server-Docker/master/6.3.3/Dockerfile)
+* ```latest```, ```6.3.3``` : [Dockerfile](https://raw.githubusercontent.com/KnowageLabs/Knowage-Server-Docker/master/6.3.3/Dockerfile)
 * ```6.1.1``` : [Dockerfile](https://raw.githubusercontent.com/KnowageLabs/Knowage-Server-Docker/master/6.1.1/Dockerfile)
 * ```6.2.0-RC``` : [Dockerfile](https://raw.githubusercontent.com/KnowageLabs/Knowage-Server-Docker/master/6.2.0-RC/Dockerfile)
 * ```6.2.2``` : [Dockerfile](https://raw.githubusercontent.com/KnowageLabs/Knowage-Server-Docker/master/6.2.2/Dockerfile)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,17 @@
 knowage:
     image: knowagelabs/knowage-server-docker:develop
+    #build: .
     links:
         - knowagedb:db
     ports:
         - "8080:8080"
     environment:
         - WAIT_MYSQL=true
+        - DB_HOST=knowagedb
+        - DB_PORT=3306
+        - DB_DB=knowagedb
+        - DB_USER=knowageuser
+        - DB_PASS=knowagepassword
 
 knowagedb:
     image: mysql:5.6

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 if [[ -z "$PUBLIC_ADDRESS" ]]; then
@@ -14,11 +14,11 @@ sed -i "s|http:\/\/localhost:8080|http:\/\/${PUBLIC_ADDRESS}:8080|g" ${KNOWAGE_D
 
 # Get the database values from the relation if user doesn't pass them throught enviroment variables.
 # This allow people to use newer docker-compose versions that doesn't support links
-[[ -z $DB_USER ]] && DB_USER=$DB_ENV_MYSQL_USER
-[[ -z $DB_DB ]] && DB_DB=$DB_ENV_MYSQL_DATABASE
-[[ -z $DB_PASS ]] && DB_PASS=$DB_ENV_MYSQL_PASSWORD
-[[ -z $DB_HOST ]] && DB_HOST=$DB_PORT_3306_TCP_ADDR
-[[ -z $DB_PORT ]] && DB_PORT=$DB_PORT_3306_TCP_PORT
+[[ -z "$DB_USER" ]] || DB_USER=$DB_ENV_MYSQL_USER
+[[ -z "$DB_DB" ]] || DB_DB=$DB_ENV_MYSQL_DATABASE
+[[ -z "$DB_PASS" ]] || DB_PASS=$DB_ENV_MYSQL_PASSWORD
+[[ -z "$DB_HOST" ]] || DB_HOST=$DB_PORT_3306_TCP_ADDR
+[[ -z "$DB_PORT" ]] || DB_PORT=$DB_PORT_3306_TCP_PORT
 
 #wait for mysql if it's a compose image
 if [ -n "$WAIT_MYSQL" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,22 +12,23 @@ sed -i "s|http:\/\/.*:8080|http:\/\/${PUBLIC_ADDRESS}:8080|g" ${KNOWAGE_DIRECTOR
 sed -i "s|http:\/\/.*:8080\/knowage|http:\/\/localhost:8080\/knowage|g" ${KNOWAGE_DIRECTORY}/${APACHE_TOMCAT_PACKAGE}/conf/server.xml
 sed -i "s|http:\/\/localhost:8080|http:\/\/${PUBLIC_ADDRESS}:8080|g" ${KNOWAGE_DIRECTORY}/${APACHE_TOMCAT_PACKAGE}/webapps/knowage/WEB-INF/web.xml
 
+# Get the database values from the relation if user doesn't pass them throught enviroment variables.
+# This allow people to use newer docker-compose versions that doesn't support links
+[[ -z $DB_USER ]] && DB_USER=$DB_ENV_MYSQL_USER
+[[ -z $DB_DB ]] && DB_DB=$DB_ENV_MYSQL_DATABASE
+[[ -z $DB_PASS ]] && DB_PASS=$DB_ENV_MYSQL_PASSWORD
+[[ -z $DB_HOST ]] && DB_HOST=$DB_PORT_3306_TCP_ADDR
+[[ -z $DB_PORT ]] && DB_PORT=$DB_PORT_3306_TCP_PORT
+
 #wait for mysql if it's a compose image
 if [ -n "$WAIT_MYSQL" ]; then
 	sleep 5
-	while ! curl http://$DB_PORT_3306_TCP_ADDR:$DB_PORT_3306_TCP_PORT/
+	while ! curl http://$DB_HOST:$DB_PORT/
 	do
 	  echo "$(date) - still trying to connect to mysql"
 	  sleep 1
 	done
 fi
-
-# Get the database values from the relation.
-DB_USER=$DB_ENV_MYSQL_USER
-DB_DB=$DB_ENV_MYSQL_DATABASE
-DB_PASS=$DB_ENV_MYSQL_PASSWORD
-DB_HOST=$DB_PORT_3306_TCP_ADDR
-DB_PORT=$DB_PORT_3306_TCP_PORT
 
 #insert knowage metadata into db if it doesn't exist
 result=`mysql -h${DB_HOST} -P${DB_PORT} -u${DB_USER} -p${DB_PASS} ${DB_DB} -e "SHOW TABLES LIKE '%SBI_%';"`


### PR DESCRIPTION
Changes to entrypoint where made to allow custom mysql servers to be used instead of a linked container.

Other changes where made to allow a quick environment to be set up.