### PR TITLE
Fix typo in docker-compose.yaml for Knowage-Server-Docker

### DIFF
--- a/Knowage-Server-Docker/docker-compose.yml
+++ b/Knowage-Server-Docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - knowagecache
       - hazelcast
     ports:
-      - "18080:8080"
+      - "8080:8080"
     networks:
       - main
     environment:


### PR DESCRIPTION
Changed port mapping of knowage service from "18080:8080" to "8080:8080" 
I assume this was a typo, because it's impossible to access the knowage web interface with the setting as it is, but after changing it as described above, the interface works as intended.